### PR TITLE
COMMERCE-2541 Accommodate Discount Levels in Minicart

### DIFF
--- a/commerce-frontend-taglib/src/main/java/com/liferay/commerce/frontend/taglib/servlet/taglib/MiniCartTag.java
+++ b/commerce-frontend-taglib/src/main/java/com/liferay/commerce/frontend/taglib/servlet/taglib/MiniCartTag.java
@@ -15,6 +15,8 @@
 package com.liferay.commerce.frontend.taglib.servlet.taglib;
 
 import com.liferay.commerce.account.model.CommerceAccount;
+import com.liferay.commerce.configuration.CommercePriceConfiguration;
+import com.liferay.commerce.constants.CommerceConstants;
 import com.liferay.commerce.constants.CommerceWebKeys;
 import com.liferay.commerce.context.CommerceContext;
 import com.liferay.commerce.frontend.taglib.internal.servlet.ServletContextUtil;
@@ -26,6 +28,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.settings.SystemSettingsLocator;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -94,6 +98,16 @@ public class MiniCartTag extends ComponentRendererTag {
 				detailsURL = String.valueOf(commerceCartPortletURL);
 			}
 
+			CommercePriceConfiguration commercePriceConfiguration =
+					_configurationProvider.getConfiguration(
+							CommercePriceConfiguration.class,
+							new SystemSettingsLocator(
+									CommerceConstants.PRICE_SERVICE_NAME));
+
+			putValue(
+					"displayDiscountLevels",
+					commercePriceConfiguration.displayDiscountLevels());
+
 			putValue("detailsUrl", detailsURL);
 
 			putValue("isDisabled", false);
@@ -134,11 +148,16 @@ public class MiniCartTag extends ComponentRendererTag {
 		_commerceOrderHttpHelper =
 			ServletContextUtil.getCommerceOrderHttpHelper();
 
+		_configurationProvider =
+				ServletContextUtil.getConfigurationProvider();
+
 		super.setPageContext(pageContext);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(MiniCartTag.class);
 
 	private CommerceOrderHttpHelper _commerceOrderHttpHelper;
+
+	private ConfigurationProvider _configurationProvider;
 
 }

--- a/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/CommerceCartItem.es.js
+++ b/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/CommerceCartItem.es.js
@@ -29,6 +29,7 @@ CommerceCartItem.STATE = {
 	collapsed: Config.bool().value(false),
 	deleteDisabled: Config.bool().value(false),
 	deleting: Config.bool().value(false),
+	displayDiscountLevels: Config.bool().value(false),
 	errorMessages: Config.array().value(
 		[]
 	),

--- a/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/CommerceCartItem.soy
+++ b/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/CommerceCartItem.soy
@@ -10,6 +10,7 @@
 	{@param sku: string }
 	{@param spritemap: string }
 	{@param quantity: int }
+	{@param displayDiscountLevels: bool|null }
 
 	{@param? errorMessages: ? }
 	{@param settings: ? }
@@ -89,6 +90,7 @@
 			{else}
 				{call Price.render}
 					{param prices: $prices /}
+					{param displayDiscountLevels: $displayDiscountLevels /}
 				{/call}
 			{/if}
 		</div>

--- a/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/MiniCart.es.js
+++ b/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/MiniCart.es.js
@@ -491,6 +491,7 @@ Cart.STATE = {
 	detailsUrl: Config.string(),
 	valid: Config.bool(),
 	disabled: Config.bool().value(false),
+	displayDiscountLevels: Config.bool().value(false),
 	pendingOperations: Config.array().value(
 		[]
 	),

--- a/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/MiniCart.soy
+++ b/commerce-frontend-taglib/src/main/resources/META-INF/resources/mini_cart/MiniCart.soy
@@ -7,6 +7,7 @@
 	{@param? detailsUrl: string}
 	{@param checkoutUrl: string}
 	{@param spritemap: string }
+	{@param? displayDiscountLevels: bool}
 
 	{@param? valid: bool}
 	{@param? disabled: bool}
@@ -124,6 +125,7 @@
 								{param updating: $product.updating /}
 								{param deleteDisabled: $product.deleteDisabled /}
 								{param spritemap: $spritemap /}
+								{param displayDiscountLevels: $displayDiscountLevels /}
 							{/call}
 						{/foreach}
 					{/if}

--- a/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/mini_cart.scss
+++ b/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/mini_cart.scss
@@ -1,17 +1,16 @@
 .commerce-cart {
-	$minicart-width: 500px;
+	$minicart-width: 550px;
 
 	@function getOpeningTranslation($direction) {
 		@return translateX(if($direction == left, -1, 1) *
 		($minicart-width + $liferay-sidebars-width));
 	}
 
-
 	background-color: $color-bg;
 	box-shadow: -20px 0 40px $color-shadow;
 	display: flex;
 	flex-direction: column;
-	max-width: 500px;
+	max-width: $minicart-width;
 	position: absolute;
 	right: 0;
 	top: 100%;
@@ -78,7 +77,8 @@
 
 		.commerce-button--block {
 			font-size: 1em;
-			text-transform: capitalize;
+			text-transform: lowercase;
+			font-variant: small-caps;
 		}
 	}
 

--- a/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/mini_cart_item.scss
+++ b/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/mini_cart_item.scss
@@ -6,11 +6,11 @@
 	border-bottom: 1px solid rgba(180,187,201,0.2);
 	color: $color-fg;
 	display: grid;
-	font-size: 13px;
+	font-size: 12px;
 	grid-gap: 15px;
 	grid-template-areas: "image content actions price delete";
-	grid-template-columns: $item-image-size 1fr auto $price-size min-content;
-	height: 94px;
+	grid-template-columns: $item-image-size 1fr auto minmax(min-content, 122px) min-content;
+	max-height: 120px;
 	overflow: hidden;
 	padding: 10px;
 	position: relative;
@@ -48,6 +48,7 @@
 
 	&__sku {
 		display: block;
+		font-size: 11px;
 	}
 
 	&__price {

--- a/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/price.scss
+++ b/commerce-theme-minium/commerce-theme-minium/src/css/minium/components/price.scss
@@ -15,7 +15,7 @@
     font-size: 20px;
     font-weight: 500;
 
-    &:first-letter {
+    &:not(&-discount):first-letter {
       margin-left: 4px;
       margin-right: 4px;
     }
@@ -43,13 +43,15 @@
     }
 
     &-percentages {
+      font-size: 10px;
+
       &::after {
         color: $color-fg;
         content: ' | ';
       }
 
       &:last-child::after {
-        content: '';
+        content: ' ';
       }
     }
   }

--- a/commerce-theme-speedwell/commerce-theme-speedwell/src/css/_variables.scss
+++ b/commerce-theme-speedwell/commerce-theme-speedwell/src/css/_variables.scss
@@ -19,6 +19,7 @@ $easeInQuart: cubic-bezier(0.895, 0.03, 0.685, 0.22);
 $easeInQuint: cubic-bezier(0.755, 0.05, 0.855, 0.06);
 $easeOutQuart: cubic-bezier(0.165, 0.84, 0.44, 1);
 $easeOutQuint: cubic-bezier(0.23, 1, 0.32, 1);
+$liferay-sidebars-width: 320px;
 $liferay-topbar-height-small: 48px;
 $liferay-topbar-height: 56px;
 $micro-transition: ease 100ms;

--- a/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_price.scss
+++ b/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_price.scss
@@ -43,13 +43,15 @@
 		}
 
 		&-percentages {
+			font-size: 10px;
+
 			&::after {
 				color: $color-fg;
 				content: ' | ';
 			}
 
 			&:last-child::after {
-				content: '';
+				content: ' ';
 			}
 		}
 	}

--- a/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_speedwell_cart.scss
+++ b/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_speedwell_cart.scss
@@ -1,22 +1,29 @@
 .speedwell-cart {
   .commerce-cart {
+    $minicart-width: 550px;
+
+    @function getOpeningTranslation($direction) {
+      @return translateX(if($direction == left, -1, 1) *
+		($minicart-width + $liferay-sidebars-width));
+    }
+
     top: 0;
     display: flex;
     flex-direction: column;
-    max-width: 500px;
+    max-width: $minicart-width;
     position: absolute;
     right: 0;
     transition: all ease 200ms;
-    width: 100%;
+    width: $minicart-width;
     height: calc(100vh - #{$topbar-height});
-  
+
     @media screen and (max-width: $bp-small) {
       height: calc(100vh - #{$topbar-height-small});
     }
-  
+
     .has-control-menu.signed-in & {
       height: calc(100vh - #{$liferay-topbar-height});
-  
+
       @media screen and (max-width: $bp-small) {
         height: calc(100vh - #{$liferay-topbar-height-small});
       }
@@ -38,29 +45,36 @@
     }
 
     &:not(.is-open) {
-      transform: translateX(100%);
+      transform: getOpeningTranslation(right);
+    }
+
+    .rtl & {
+      left: 0;
+    }
+
+    .rtl &:not(.is-open) {
+      transform: getOpeningTranslation(left);
     }
 
     &__container {
       background-color: $color-bg;
       box-shadow: -20px 0 40px $color-shadow;
       position: absolute;
-      top: 0;
       right: 0;
       height: calc(100vh - #{$topbar-height});
       width: 100%;
       display: flex;
       flex-direction: column;
       top: $topbar-height;
-  
+
       @media screen and (max-width: $bp-small) {
         height: calc(100vh - #{$topbar-height-small});
         top: $topbar-height-small;
       }
-  
+
       .has-control-menu.signed-in & {
         height: calc(100vh - #{$liferay-topbar-height + $topbar-height});
-    
+
         @media screen and (max-width: $bp-small) {
           height: calc(100vh - #{$liferay-topbar-height-small + $topbar-height-small});
         }

--- a/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_speedwell_cart_item.scss
+++ b/commerce-theme-speedwell/commerce-theme-speedwell/src/css/components/_speedwell_cart_item.scss
@@ -7,10 +7,10 @@
   border-bottom: 1px solid rgba(180, 187, 201, 0.2);
   color: $stroke;
   display: grid;
-  font-size: 13px;
+  font-size: 12px;
   grid-gap: 15px;
-	grid-template-areas: "image content actions price delete";
-	grid-template-columns: $item-image-size 1fr auto $price-size min-content;
+  grid-template-areas: "image content actions price delete";
+  grid-template-columns: $item-image-size 1fr auto minmax(min-content, 122px) min-content;
   max-height: 140px;
   overflow: hidden;
   padding: 10px;


### PR DESCRIPTION
@marco-leo I know you told me that we don't need to edit the MiniCart Tag, but I do think we do, as the Minicart calls the Price component as a child and needs the `displayDiscountLevels` parameter to be taken from the backend. Since, for the Minicart, we're not passing through the Price Tag, I don't see any other way.

Correct or not? :o